### PR TITLE
Calculate the difference in the other direction

### DIFF
--- a/src/main/java/lblod/info/datasetdiff/AppService.java
+++ b/src/main/java/lblod/info/datasetdiff/AppService.java
@@ -42,14 +42,19 @@ public class AppService {
                     previousCompletedModel = taskService.fetchTripleFromPreviousJobs(task);
                 }
 
-                var diff = ModelUtils.difference(importedTriples, previousCompletedModel);
+                var newInserts = ModelUtils.difference(importedTriples, previousCompletedModel);
+                var toRemoveOld = ModelUtils.difference(previousCompletedModel, importedTriples);
                 var intersection = ModelUtils.intersection(importedTriples, previousCompletedModel);
 
                 var dataDiffContainer = fileContainer.toBuilder()
-                        .graphUri(taskService.writeTtlFile(task.getGraph(), diff, ("diff-triples.ttl")))
+                        .graphUri(taskService.writeTtlFile(task.getGraph(), newInserts, "new-insert-triples.ttl"))
                         .build();
                 taskService.appendTaskResultFile(task, dataDiffContainer);
 
+                var dataRemovalsContainer = fileContainer.toBuilder()
+                        .graphUri(taskService.writeTtlFile(task.getGraph(), toRemoveOld, "to-remove-triples.ttl"))
+                        .build();
+                taskService.appendTaskResultFile(task, dataRemovalsContainer);
                 var dataIntersectContainer = fileContainer
                         .toBuilder()
                         .graphUri(taskService.writeTtlFile(task.getGraph(), intersection, "intersect-triples.ttl"))


### PR DESCRIPTION
This PR will attempt to create an extra file that is also persisted. This file contains the triples that are removed from a previous time this service has imported triples for a document.

The addition of this file allows for cleaning up old triples that are replaced by new ones. E.g. when an update to a document is published to correct a typo, this service now also calculates the triple that needs to be removed on top of the triple representing the new value.