### PR TITLE
Do not ignore empty models

### DIFF
--- a/src/main/java/lblod/info/datasetdiff/AppService.java
+++ b/src/main/java/lblod/info/datasetdiff/AppService.java
@@ -37,10 +37,7 @@ public class AppService {
                 log.info("input container: {}", inputContainer);
                 var importedTriples = taskService.fetchTripleFromFileInputContainer(inputContainer.getGraphUri());
                 var fileContainer = DataContainer.builder().build();
-                var previousCompletedModel = ModelFactory.createDefaultModel();
-                if (!importedTriples.isEmpty()) {
-                    previousCompletedModel = taskService.fetchTripleFromPreviousJobs(task);
-                }
+                var previousCompletedModel = taskService.fetchTripleFromPreviousJobs(task);
 
                 var newInserts = ModelUtils.difference(importedTriples, previousCompletedModel);
                 var toRemoveOld = ModelUtils.difference(previousCompletedModel, importedTriples);


### PR DESCRIPTION
Remove the conditional that stop the previous model from being fetched when the current model is empty. An empty model might be a way of saying "remove all that was harvested the previous time for this document" and can not be ignored.